### PR TITLE
Don't JSON encode token request.

### DIFF
--- a/server.py
+++ b/server.py
@@ -71,7 +71,7 @@ def signIn():
                 'grant_type': 'authorization_code' 
         }
     
-        r=requests.post('https://www.googleapis.com/oauth2/v4/token', data=json.dumps(payload))
+        r=requests.post('https://www.googleapis.com/oauth2/v4/token', data=payload)
         print r.text
         return r.text
         


### PR DESCRIPTION
The parameters are supposed to be `x-www-form-urlencoded`, not JSON encoded. If we just give requests a dict, it will take care of the rest!